### PR TITLE
Replace icatUrl with facilityName in topcat requests

### DIFF
--- a/pollcat.config
+++ b/pollcat.config
@@ -6,6 +6,9 @@ ICAT_URL: https://myicaturl:8181/
 TOPCAT_URL: https://mytopcaturl:8181/
 IDS_URL: https://myidsurl:8181/
 
+# Facility name (as known by Topcat)
+FACILITY_NAME: MFN
+
 # timeout for getDatafileIds request
 DATAFILEIDS_TIMEOUT: 30
 

--- a/pollcat.py
+++ b/pollcat.py
@@ -64,9 +64,9 @@ def updateDownloadRequest(preparedId, downloadId):
     r = requests.put(
         url=config.get('main', 'TOPCAT_URL') + '/topcat/admin/download/' + str(downloadId) + '/status',
         params={
-            'icatUrl'   : config.get('main', 'ICAT_URL'), 
-            'sessionId' : icatclient.getInstance().sessionId,
-            'value'     : 'COMPLETE'
+            'facilityName'   : config.get('main', 'FACILITY_NAME'), 
+            'sessionId'      : icatclient.getInstance().sessionId,
+            'value'          : 'COMPLETE'
         },
         headers={"Content-type": "application/x-www-form-urlencoded; charset=UTF-8"}
     )
@@ -81,11 +81,11 @@ def getDownloadRequests():
     response = requests.get(
         url=config.get('main', 'TOPCAT_URL') + '/topcat/admin/downloads',
         params={
-            'icatUrl'     : config.get('main', 'ICAT_URL'), 
-            'sessionId'   : icatclient.getInstance().sessionId,
-            'queryOffset' : "where download.transport = '" + config.get('main', 'PLUGIN_NAME') + 
-                            "' and download.isDeleted = false and download.status = " +
-                            "org.icatproject.topcat.domain.DownloadStatus.RESTORING"
+            'facilityName' : config.get('main', 'FACILITY_NAME'), 
+            'sessionId'    : icatclient.getInstance().sessionId,
+            'queryOffset'  : "where download.transport = '" + config.get('main', 'PLUGIN_NAME') + 
+                             "' and download.isDeleted = false and download.status = " +
+                             "org.icatproject.topcat.domain.DownloadStatus.RESTORING"
         }
     )
     downloadrequests = json.loads(response.text)


### PR DESCRIPTION
Added new FACILITY_NAME property to pollcat.config; this is passed to topcat instead of the icatUrl.
Fixes #2.

Note that after this change, pollcat will no longer work with earlier (<2.4.0) versions of Topcat.